### PR TITLE
Allow bypass of the ping check during update of publisher; use in CI/CD

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [ main, bypass-ping ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main, bypass-ping ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -38,12 +38,17 @@ jobs:
         with:
           ruby-version: '2.7'
 
-      - run: gem install bundler
-      - run: bundle install # For Jekyll
-      - run: bash _updatePublisher.sh --force --yes --skip-ping
-      - run: bash _genonce.sh
-      - run: npm install jsonfile
-      - name: Bump semver of package
+      - name: Install Jekyll
+        run: |
+          gem install bundler
+          bundle install
+      - name: Update Publisher executable
+        run: bash _updatePublisher.sh --force --yes --skip-ping
+      - name: Generate Implementation Guide (IG)
+        run: bash _genonce.sh
+      - name: Install jsonfile package
+        run: npm install jsonfile
+      - name: Publish to Package Repository
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash _publishToRepo.sh

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -40,7 +40,7 @@ jobs:
 
       - run: gem install bundler
       - run: bundle install # For Jekyll
-      - run: bash _updatePublisher.sh --force --yes
+      - run: bash _updatePublisher.sh --force --yes --skip-ping
       - run: bash _genonce.sh
       - run: npm install jsonfile
       - name: Bump semver of package

--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -30,17 +30,17 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
-echo "Checking internet connection"
-case "$OSTYPE" in
-  linux-gnu* ) ping tx.fhir.org -4 -c 1 -w 30 >/dev/null ;;
-  darwin* )	ping tx.fhir.org -c 1 >/dev/null ;;
-  *) echo "unknown: $OSTYPE"; exit 1 ;;
-esac
-
-if [ $? -ne 0 ] ; then
-  echo "Offline (or the terminology server is down), unable to update.  Exiting"
-  exit 1
-fi
+#echo "Checking internet connection"
+#case "$OSTYPE" in
+#  linux-gnu* ) ping tx.fhir.org -4 -c 1 -w 30 >/dev/null ;;
+#  darwin* )	ping tx.fhir.org -c 1 >/dev/null ;;
+#  *) echo "unknown: $OSTYPE"; exit 1 ;;
+#esac
+#
+#if [ $? -ne 0 ] ; then
+#  echo "Offline (or the terminology server is down), unable to update.  Exiting"
+#  exit 1
+#fi
 
 if [ ! -d "$input_cache_path" ] ; then
   if [ $FORCE != true ]; then

--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -13,6 +13,7 @@ gencont_sh_url=$scriptdlroot/_gencontinuous.sh
 gen_sh_url=$scriptdlroot/_genonce.sh
 update_sh_url=$scriptdlroot/_updatePublisher.sh
 
+skipPing=false
 skipPrompts=false
 FORCE=false
 
@@ -23,6 +24,7 @@ fi
 
 while [ "$#" -gt 0 ]; do
     case $1 in
+    --skip-ping)  skipPing=true ;;
     -f|--force)  FORCE=true ;;
     -y|--yes)  skipPrompts=true ; FORCE=true ;;
     *)  echo "Unknown parameter passed: $1.  Exiting"; exit 1 ;;
@@ -30,17 +32,19 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
-#echo "Checking internet connection"
-#case "$OSTYPE" in
-#  linux-gnu* ) ping tx.fhir.org -4 -c 1 -w 30 >/dev/null ;;
-#  darwin* )	ping tx.fhir.org -c 1 >/dev/null ;;
-#  *) echo "unknown: $OSTYPE"; exit 1 ;;
-#esac
-#
-#if [ $? -ne 0 ] ; then
-#  echo "Offline (or the terminology server is down), unable to update.  Exiting"
-#  exit 1
-#fi
+if [[ $skipPing == false ]]; then
+  echo "Checking internet connection"
+  case "$OSTYPE" in
+    linux-gnu* ) ping tx.fhir.org -4 -c 1 -w 30 >/dev/null ;;
+    darwin* )	ping tx.fhir.org -c 1 >/dev/null ;;
+    *) echo "unknown: $OSTYPE"; exit 1 ;;
+  esac
+
+  if [ $? -ne 0 ] ; then
+    echo "Offline (or the terminology server is down), unable to update.  Exiting"
+    exit 1
+  fi
+fi
 
 if [ ! -d "$input_cache_path" ] ; then
   if [ $FORCE != true ]; then

--- a/library-package.json
+++ b/library-package.json
@@ -1,4 +1,4 @@
 {
   "name": "@chronic-care/covid-ed-ig",
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/library-package.json
+++ b/library-package.json
@@ -1,4 +1,4 @@
 {
   "name": "@chronic-care/covid-ed-ig",
-  "version": "0.0.6"
+  "version": "0.0.7"
 }

--- a/library-package.json
+++ b/library-package.json
@@ -1,4 +1,4 @@
 {
   "name": "@chronic-care/covid-ed-ig",
-  "version": "0.0.7"
+  "version": "0.0.8"
 }


### PR DESCRIPTION
Add a `--skip-ping` argument to `_updatePublisher.sh`.

Use `--skip-ping` argument in `build-package.yml` to get around [the disabling of `ping` connections within GitHub Actions containers](https://github.com/actions/virtual-environments/issues/1519#issuecomment-683790054).