### PR TITLE
Update logic for Blood Pressure and add view objects

### DIFF
--- a/input/cql/COVID_19_ED_Severity_FHIRv400.cql
+++ b/input/cql/COVID_19_ED_Severity_FHIRv400.cql
@@ -26,10 +26,10 @@ include COVID_19_Concepts version '1.0.0' called CC
 
 // 12 months for test data, use '24 hours' as default in production?
 // Or, get current, active (?) Patient Encounter(s) and find Observations associated with those Encounters
-parameter VitalSignsLookbackPeriod default 12 months
+parameter VitalSignsLookbackPeriod default 2 months
 
 // 12 months for test data, use '2 days' as default in production?
-parameter LabResultsLookbackPeriod default 12 months
+parameter LabResultsLookbackPeriod default 2 months
 
 // # CDS logic #
 
@@ -94,31 +94,29 @@ define "Last SBP value":
 define "Blood Pressure Observations":
  ("Blood Pressure Observation Components"
     union "Systolic Blood Pressure Observations")
-    //union "Diastolic Blood Pressure Observations")
 
 // Use when Systolic BP is reported as an independent Observation (not recommended)
 define "Systolic Blood Pressure Observations":
   (C3F.ObservationLookBack(
     C3F.Verified([Observation: CC."Systolic blood pressure"]),
     VitalSignsLookbackPeriod)) bp
+      let SystolicValue: Round((bp.value as FHIR.Quantity).value),
+          DiastolicValue: Round((MatchingDiastolic(bp).value as FHIR.Quantity).value)
     return {
       "Date": ObservationDate(bp),
-      "Systolic": ToString((bp.value as FHIR.Quantity).value),
-      "Diasystolic": null
+      "Systolic": SystolicValue,
+      "Diastolic": DiastolicValue,
+      "Display": Coalesce(ToString(SystolicValue), '-') + '/' + Coalesce(ToString(DiastolicValue), '-')
     }
     sort by Date asc
 
-// Use when Diastolic BP is reported as an independent Observation (not recommended)
-define "Diastolic Blood Pressure Observations":
+define function MatchingDiastolic(SystolicBP FHIR.Observation):
+  First(
   (C3F.ObservationLookBack(
     C3F.Verified([Observation: CC."Diastolic blood pressure"]),
     VitalSignsLookbackPeriod)) bp
-    return {
-      "Date": ObservationDate(bp),
-      "Systolic": null,
-      "Diasystolic": ToString((bp.value as FHIR.Quantity).value)
-    }
-    sort by Date asc
+      where (bp.effective as FHIR.dateTime) = (SystolicBP.effective as FHIR.dateTime)
+  )
 
 // TODO move into Commons library
 define function ComponentValue(Obs FHIR.Observation, code System.Code):
@@ -127,28 +125,31 @@ define function ComponentValue(Obs FHIR.Observation, code System.Code):
 
 // Use the following if Systolic and Diastolic are combined as components within one Observation.
 define "Blood Pressure Observation Components":
- (C3F.ObservationLookBack(C3F.Verified([Observation: CC."Blood pressure"]), VitalSignsLookbackPeriod)) bp
- return {
-   "Date": ObservationDate(bp),
-   "Systolic": ToString(ComponentValue(bp, CC."Systolic blood pressure").value),
-   "Diasystolic": ToString(ComponentValue(bp, CC."Diastolic blood pressure").value)
- }
- sort by Date asc
-
-define "Last O2 Saturation":
-  C3F.MostRecent("O2 Saturation Observations")
+  (C3F.ObservationLookBack(C3F.Verified([Observation: CC."Blood pressure"]), VitalSignsLookbackPeriod)) bp
+    let SystolicValue: Round(ComponentValue(bp, CC."Systolic blood pressure").value),
+        DiastolicValue: Round(ComponentValue(bp, CC."Diastolic blood pressure").value)
+   return {
+     "Date": ObservationDate(bp),
+     "Systolic": SystolicValue,
+     "Diastolic": DiastolicValue,
+     "Display": Coalesce(ToString(SystolicValue), '-') + '/' + Coalesce(ToString(DiastolicValue), '-')
+   }
+   sort by Date asc
 
 define "Last O2 Saturation value":
-  C3F.QuantityValue("Last O2 Saturation").value
+  C3F.QuantityValue(C3F.MostRecent("O2 Saturation Observations")).value
+
+define "Lowest O2 Saturation value":
+  C3F.LowestObservation("O2 Saturation Observations").value
 
 // TODO lowest in what period?  24 hours before last value?  In current Encounter(s)?
 define "Lowest O2 Saturation percent":
   // O2 Saturation should be reported as a percent, e.g. 92.
-  if "Last O2 Saturation value" >= 1 then
-   "Last O2 Saturation value"
+  if "Lowest O2 Saturation value" >= 1 then
+   "Lowest O2 Saturation value"
   else
     // If reported as decimal .92, then multiply by 100.
-    Round("Last O2 Saturation value" * 100)
+    Round("Lowest O2 Saturation value" * 100)
 
 define "O2 Saturation Observations":
   C3F.ObservationLookBack(
@@ -346,7 +347,7 @@ define function ReportObservations(ObsList List<Observation>):
     return {   // result decimal value
       Date:   ObservationDate(o),
       // Omit display name because observations are in a typed collection
-      //Name:   ConceptText(o.code),                              // display nanme
+      Name:   ConceptText(o.code),                                // display nanme
       Result: QuantityText(o.value as FHIR.Quantity),             // result value with units
       ResultValue: ToString((o.value as FHIR.Quantity).value)
     }

--- a/input/cql/COVID_19_ED_Severity_FHIRv400.cql
+++ b/input/cql/COVID_19_ED_Severity_FHIRv400.cql
@@ -75,49 +75,80 @@ define "Patient Race Text":
  */
 
 define "Last Heart Rate":
-  C3F.MostRecent(HeartRateObservations)
+  C3F.MostRecent("Heart Rate Observations")
 
 define "Last Heart Rate value":
   C3F.QuantityValue("Last Heart Rate")
 
-define HeartRateObservations:
+define "Heart Rate Observations":
   C3F.ObservationLookBack(
     C3F.Verified([Observation: CC."Heart rate"]),
     VitalSignsLookbackPeriod)
 
 define "Last SBP":
-  C3F.MostRecent("Systolic Blood Pressure Readings")
+  Last("Blood Pressure Observations" o where o.Systolic is not null)
 
 define "Last SBP value":
-  C3F.QuantityValue("Last SBP")
+  "Last SBP".Systolic
 
-define "Systolic Blood Pressure Readings":
-  C3F.ObservationLookBack(
+define "Blood Pressure Observations":
+ ("Blood Pressure Observation Components"
+    union "Systolic Blood Pressure Observations")
+    //union "Diastolic Blood Pressure Observations")
+
+// Use when Systolic BP is reported as an independent Observation (not recommended)
+define "Systolic Blood Pressure Observations":
+  (C3F.ObservationLookBack(
     C3F.Verified([Observation: CC."Systolic blood pressure"]),
-    VitalSignsLookbackPeriod)
+    VitalSignsLookbackPeriod)) bp
+    return {
+      "Date": ObservationDate(bp),
+      "Systolic": ToString((bp.value as FHIR.Quantity).value),
+      "Diasystolic": null
+    }
+    sort by Date asc
+
+// Use when Diastolic BP is reported as an independent Observation (not recommended)
+define "Diastolic Blood Pressure Observations":
+  (C3F.ObservationLookBack(
+    C3F.Verified([Observation: CC."Diastolic blood pressure"]),
+    VitalSignsLookbackPeriod)) bp
+    return {
+      "Date": ObservationDate(bp),
+      "Systolic": null,
+      "Diasystolic": ToString((bp.value as FHIR.Quantity).value)
+    }
+    sort by Date asc
+
+// TODO move into Commons library
+define function ComponentValue(Obs FHIR.Observation, code System.Code):
+  First(Obs.component c
+    where c.code ~ ToConcept(code)).value as FHIR.Quantity
 
 // Use the following if Systolic and Diastolic are combined as components within one Observation.
-/*
-define "Systolic Blood Pressure Readings":
-	[Observation: CC."Blood pressure"] BloodPressure
-	  where BloodPressure.status in {'final', 'amended'}
-     and BloodPressure.effective during "Vital Signs Measurement Period"
-	    // and not (GetEncounter(BloodPressure.encounter).class.code in { 'EMER', 'IMP', 'ACUTE', 'NONAC', 'PRENC', 'SS'})
-     and exists (
-       BloodPressure.component SystolicBP
-	        where SystolicBP.code ~ ToConcept(CC."Systolic blood pressure")
-     )
-*/
+define "Blood Pressure Observation Components":
+ (C3F.ObservationLookBack(C3F.Verified([Observation: CC."Blood pressure"]), VitalSignsLookbackPeriod)) bp
+ return {
+   "Date": ObservationDate(bp),
+   "Systolic": ToString(ComponentValue(bp, CC."Systolic blood pressure").value),
+   "Diasystolic": ToString(ComponentValue(bp, CC."Diastolic blood pressure").value)
+ }
+ sort by Date asc
 
 define "Last O2 Saturation":
   C3F.MostRecent("O2 Saturation Observations")
 
-define "Last O2 Saturation percent":
-  Round(C3F.QuantityValue("Last O2 Saturation").value * 100)
+define "Last O2 Saturation value":
+  C3F.QuantityValue("Last O2 Saturation").value
 
 // TODO lowest in what period?  24 hours before last value?  In current Encounter(s)?
 define "Lowest O2 Saturation percent":
-  Round(C3F.LowestObservation("O2 Saturation Observations").value * 100)
+  // O2 Saturation should be reported as a percent, e.g. 92.
+  if "Last O2 Saturation value" >= 1 then
+   "Last O2 Saturation value"
+  else
+    // If reported as decimal .92, then multiply by 100.
+    Round("Last O2 Saturation value" * 100)
 
 define "O2 Saturation Observations":
   C3F.ObservationLookBack(
@@ -268,3 +299,78 @@ define "Has Renal Disease Risk Factor":
  */
 
 // TODO Retrieve and evaluate lab results
+
+
+/***
+ * TODO: Move these view object definitions to a separate CQL library.
+ */
+// SUMMARY
+
+// Returns the first-found display text for a CodeableConcept, looking first at the `text` attribute, then the
+// `display` on each `coding` until it finds a non-null value.
+// @param c - a FHIR CodeableConcept to get text from
+// @returns {System.String} the display text or null if none is found
+define function ConceptText(c FHIR.CodeableConcept):
+  Coalesce(c.text.value, Coalesce((c.coding) c2 return c2.display.value), Coalesce((c.coding) c3 return c3.code.value))
+
+// Returns a text representation of a Quantity with the Quantity's value and unit.
+// If the unit is {score}, then omit it (as it is not useful to display)
+// @param q - a FHIR Quantity to get text for
+// @returns {System.String} the text representation of the Quantity
+define function QuantityText(q FHIR.Quantity):
+  if (q is null) then null
+  else if (q.unit is not null and q.unit.value != '{score}') then ToString(q.value.value) + ' ' + q.unit.value
+  else if (q.code is not null and q.code.value != '{score}') then ToString(q.value.value) + ' ' + q.code.value
+  else ToString(q.value.value)
+
+// Returns a text representation of a date associated with an Observation, preferring `effectiveDateTime`, then
+// `effectivePeriod.start`, then `issued`.
+// @param o - a FHIR Observation to get the text date from
+// @returns {System.String} the text representation of a relevant date from the Observation
+define function ObservationDate(o FHIR.Observation):
+  Coalesce(
+    ToString((o.effective as FHIR.dateTime).value),
+    ToString((o.effective as FHIR.instant).value),
+    ToString(((o.effective as FHIR.Period)."start").value),
+    ToString(o.issued.value)
+  )
+
+define ReportPatientName:
+  Coalesce(Patient.name[0].text.value,
+    (Combine(Patient.name.given G return G.value, ' ') + ' ' + Combine(Patient.name.family F return F.value, ' '))
+  )
+
+// Returns a list of observation view Tuples.
+define function ReportObservations(ObsList List<Observation>):
+  ObsList o
+    return {   // result decimal value
+      Date:   ObservationDate(o),
+      // Omit display name because observations are in a typed collection
+      //Name:   ConceptText(o.code),                              // display nanme
+      Result: QuantityText(o.value as FHIR.Quantity),             // result value with units
+      ResultValue: ToString((o.value as FHIR.Quantity).value)
+    }
+    sort by Date asc
+
+// The Summary object represents the full COVID-19 Risk Assessment to be displayed to the clinician.  All values are
+// returned as user-friendly text representations, but a robust user interface (UI) should be implemented to
+// display the data to the user in a friendly manner.
+
+define Summary: {
+  Patient: {
+    Name: ReportPatientName,
+    Gender: Patient.gender.value,
+    Age: AgeInYears(),
+    Race: "Patient Race Text"
+  },
+  ClinicalAssessment: {
+    HeartRate: ReportObservations("Heart Rate Observations"),
+    BloodPressure: "Blood Pressure Observations",
+    O2Saturation: ReportObservations("O2 Saturation Observations"),
+    RespiratoryRate: ReportObservations("Respiratory Rate Observations"),
+    O2FlowRate: ReportObservations("O2 Flow Rate Observations")
+  },
+  DiagnosticAssessment: {
+    // add lab results here
+  }
+}

--- a/input/cql/FHIRHelpers.cql
+++ b/input/cql/FHIRHelpers.cql
@@ -1,0 +1,368 @@
+library FHIRHelpers version '4.0.1'
+
+using FHIR version '4.0.1'
+
+define function ToInterval(period FHIR.Period):
+    if period is null then
+        null
+    else
+        if period."start" is null then
+            Interval(period."start".value, period."end".value]
+        else
+            Interval[period."start".value, period."end".value]
+
+define function ToCalendarUnit(unit System.String):
+    case unit
+        when 'ms' then 'millisecond'
+        when 's' then 'second'
+        when 'min' then 'minute'
+        when 'h' then 'hour'
+        when 'd' then 'day'
+        when 'wk' then 'week'
+        when 'mo' then 'month'
+        when 'a' then 'year'
+        else unit
+    end
+
+define function ToQuantity(quantity FHIR.Quantity):
+    case
+        when quantity is null then null
+        when quantity.value is null then null
+        when quantity.comparator is not null then
+            Message(null, true, 'FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported', 'Error', 'FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.')
+        when quantity.system is null or quantity.system.value = 'http://unitsofmeasure.org'
+              or quantity.system.value = 'http://hl7.org/fhirpath/CodeSystem/calendar-units' then
+            System.Quantity { value: quantity.value.value, unit: ToCalendarUnit(Coalesce(quantity.code.value, quantity.unit.value, '1')) }
+        else
+            Message(null, true, 'FHIRHelpers.ToQuantity.InvalidFHIRQuantity', 'Error', 'Invalid FHIR Quantity code: ' & quantity.unit.value & ' (' & quantity.system.value & '|' & quantity.code.value & ')')
+    end
+
+define function ToQuantityIgnoringComparator(quantity FHIR.Quantity):
+    case
+        when quantity is null then null
+        when quantity.value is null then null
+        when quantity.system is null or quantity.system.value = 'http://unitsofmeasure.org'
+              or quantity.system.value = 'http://hl7.org/fhirpath/CodeSystem/calendar-units' then
+            System.Quantity { value: quantity.value.value, unit: ToCalendarUnit(Coalesce(quantity.code.value, quantity.unit.value, '1')) }
+        else
+            Message(null, true, 'FHIRHelpers.ToQuantity.InvalidFHIRQuantity', 'Error', 'Invalid FHIR Quantity code: ' & quantity.unit.value & ' (' & quantity.system.value & '|' & quantity.code.value & ')')
+    end
+
+define function ToInterval(quantity FHIR.Quantity):
+    if quantity is null then null else
+        case quantity.comparator.value
+            when '<' then
+                Interval[
+                    null,
+                    ToQuantityIgnoringComparator(quantity)
+                )
+            when '<=' then
+                Interval[
+                    null,
+                    ToQuantityIgnoringComparator(quantity)
+                ]
+            when '>=' then
+                Interval[
+                    ToQuantityIgnoringComparator(quantity),
+                    null
+                ]
+            when '>' then
+                Interval(
+                    ToQuantityIgnoringComparator(quantity),
+                    null
+                ]
+            else
+                Interval[ToQuantity(quantity), ToQuantity(quantity)]
+        end
+
+define function ToRatio(ratio FHIR.Ratio):
+    if ratio is null then
+        null
+    else
+        System.Ratio { numerator: ToQuantity(ratio.numerator), denominator: ToQuantity(ratio.denominator) }
+
+define function ToInterval(range FHIR.Range):
+    if range is null then
+        null
+    else
+        Interval[ToQuantity(range.low), ToQuantity(range.high)]
+
+define function ToCode(coding FHIR.Coding):
+    if coding is null then
+        null
+    else
+        System.Code {
+          code: coding.code.value,
+          system: coding.system.value,
+          version: coding.version.value,
+          display: coding.display.value
+        }
+
+define function ToConcept(concept FHIR.CodeableConcept):
+    if concept is null then
+        null
+    else
+        System.Concept {
+            codes: concept.coding C return ToCode(C),
+            display: concept.text.value
+        }
+
+
+define function ToString(value AccountStatus): value.value
+define function ToString(value ActionCardinalityBehavior): value.value
+define function ToString(value ActionConditionKind): value.value
+define function ToString(value ActionGroupingBehavior): value.value
+define function ToString(value ActionParticipantType): value.value
+define function ToString(value ActionPrecheckBehavior): value.value
+define function ToString(value ActionRelationshipType): value.value
+define function ToString(value ActionRequiredBehavior): value.value
+define function ToString(value ActionSelectionBehavior): value.value
+define function ToString(value ActivityDefinitionKind): value.value
+define function ToString(value ActivityParticipantType): value.value
+define function ToString(value AddressType): value.value
+define function ToString(value AddressUse): value.value
+define function ToString(value AdministrativeGender): value.value
+define function ToString(value AdverseEventActuality): value.value
+define function ToString(value AggregationMode): value.value
+define function ToString(value AllergyIntoleranceCategory): value.value
+define function ToString(value AllergyIntoleranceCriticality): value.value
+define function ToString(value AllergyIntoleranceSeverity): value.value
+define function ToString(value AllergyIntoleranceType): value.value
+define function ToString(value AppointmentStatus): value.value
+define function ToString(value AssertionDirectionType): value.value
+define function ToString(value AssertionOperatorType): value.value
+define function ToString(value AssertionResponseTypes): value.value
+define function ToString(value AuditEventAction): value.value
+define function ToString(value AuditEventAgentNetworkType): value.value
+define function ToString(value AuditEventOutcome): value.value
+define function ToString(value BindingStrength): value.value
+define function ToString(value BiologicallyDerivedProductCategory): value.value
+define function ToString(value BiologicallyDerivedProductStatus): value.value
+define function ToString(value BiologicallyDerivedProductStorageScale): value.value
+define function ToString(value BundleType): value.value
+define function ToString(value CapabilityStatementKind): value.value
+define function ToString(value CarePlanActivityKind): value.value
+define function ToString(value CarePlanActivityStatus): value.value
+define function ToString(value CarePlanIntent): value.value
+define function ToString(value CarePlanStatus): value.value
+define function ToString(value CareTeamStatus): value.value
+define function ToString(value CatalogEntryRelationType): value.value
+define function ToString(value ChargeItemDefinitionPriceComponentType): value.value
+define function ToString(value ChargeItemStatus): value.value
+define function ToString(value ClaimResponseStatus): value.value
+define function ToString(value ClaimStatus): value.value
+define function ToString(value ClinicalImpressionStatus): value.value
+define function ToString(value CodeSearchSupport): value.value
+define function ToString(value CodeSystemContentMode): value.value
+define function ToString(value CodeSystemHierarchyMeaning): value.value
+define function ToString(value CommunicationPriority): value.value
+define function ToString(value CommunicationRequestStatus): value.value
+define function ToString(value CommunicationStatus): value.value
+define function ToString(value CompartmentCode): value.value
+define function ToString(value CompartmentType): value.value
+define function ToString(value CompositionAttestationMode): value.value
+define function ToString(value CompositionStatus): value.value
+define function ToString(value ConceptMapEquivalence): value.value
+define function ToString(value ConceptMapGroupUnmappedMode): value.value
+define function ToString(value ConditionalDeleteStatus): value.value
+define function ToString(value ConditionalReadStatus): value.value
+define function ToString(value ConsentDataMeaning): value.value
+define function ToString(value ConsentProvisionType): value.value
+define function ToString(value ConsentState): value.value
+define function ToString(value ConstraintSeverity): value.value
+define function ToString(value ContactPointSystem): value.value
+define function ToString(value ContactPointUse): value.value
+define function ToString(value ContractPublicationStatus): value.value
+define function ToString(value ContractStatus): value.value
+define function ToString(value ContributorType): value.value
+define function ToString(value CoverageStatus): value.value
+define function ToString(value CurrencyCode): value.value
+define function ToString(value DayOfWeek): value.value
+define function ToString(value DaysOfWeek): value.value
+define function ToString(value DetectedIssueSeverity): value.value
+define function ToString(value DetectedIssueStatus): value.value
+define function ToString(value DeviceMetricCalibrationState): value.value
+define function ToString(value DeviceMetricCalibrationType): value.value
+define function ToString(value DeviceMetricCategory): value.value
+define function ToString(value DeviceMetricColor): value.value
+define function ToString(value DeviceMetricOperationalStatus): value.value
+define function ToString(value DeviceNameType): value.value
+define function ToString(value DeviceRequestStatus): value.value
+define function ToString(value DeviceUseStatementStatus): value.value
+define function ToString(value DiagnosticReportStatus): value.value
+define function ToString(value DiscriminatorType): value.value
+define function ToString(value DocumentConfidentiality): value.value
+define function ToString(value DocumentMode): value.value
+define function ToString(value DocumentReferenceStatus): value.value
+define function ToString(value DocumentRelationshipType): value.value
+define function ToString(value EligibilityRequestPurpose): value.value
+define function ToString(value EligibilityRequestStatus): value.value
+define function ToString(value EligibilityResponsePurpose): value.value
+define function ToString(value EligibilityResponseStatus): value.value
+define function ToString(value EnableWhenBehavior): value.value
+define function ToString(value EncounterLocationStatus): value.value
+define function ToString(value EncounterStatus): value.value
+define function ToString(value EndpointStatus): value.value
+define function ToString(value EnrollmentRequestStatus): value.value
+define function ToString(value EnrollmentResponseStatus): value.value
+define function ToString(value EpisodeOfCareStatus): value.value
+define function ToString(value EventCapabilityMode): value.value
+define function ToString(value EventTiming): value.value
+define function ToString(value EvidenceVariableType): value.value
+define function ToString(value ExampleScenarioActorType): value.value
+define function ToString(value ExplanationOfBenefitStatus): value.value
+define function ToString(value ExposureState): value.value
+define function ToString(value ExtensionContextType): value.value
+define function ToString(value FHIRAllTypes): value.value
+define function ToString(value FHIRDefinedType): value.value
+define function ToString(value FHIRDeviceStatus): value.value
+define function ToString(value FHIRResourceType): value.value
+define function ToString(value FHIRSubstanceStatus): value.value
+define function ToString(value FHIRVersion): value.value
+define function ToString(value FamilyHistoryStatus): value.value
+define function ToString(value FilterOperator): value.value
+define function ToString(value FlagStatus): value.value
+define function ToString(value GoalLifecycleStatus): value.value
+define function ToString(value GraphCompartmentRule): value.value
+define function ToString(value GraphCompartmentUse): value.value
+define function ToString(value GroupMeasure): value.value
+define function ToString(value GroupType): value.value
+define function ToString(value GuidanceResponseStatus): value.value
+define function ToString(value GuidePageGeneration): value.value
+define function ToString(value GuideParameterCode): value.value
+define function ToString(value HTTPVerb): value.value
+define function ToString(value IdentifierUse): value.value
+define function ToString(value IdentityAssuranceLevel): value.value
+define function ToString(value ImagingStudyStatus): value.value
+define function ToString(value ImmunizationEvaluationStatus): value.value
+define function ToString(value ImmunizationStatus): value.value
+define function ToString(value InvoicePriceComponentType): value.value
+define function ToString(value InvoiceStatus): value.value
+define function ToString(value IssueSeverity): value.value
+define function ToString(value IssueType): value.value
+define function ToString(value LinkType): value.value
+define function ToString(value LinkageType): value.value
+define function ToString(value ListMode): value.value
+define function ToString(value ListStatus): value.value
+define function ToString(value LocationMode): value.value
+define function ToString(value LocationStatus): value.value
+define function ToString(value MeasureReportStatus): value.value
+define function ToString(value MeasureReportType): value.value
+define function ToString(value MediaStatus): value.value
+define function ToString(value MedicationAdministrationStatus): value.value
+define function ToString(value MedicationDispenseStatus): value.value
+define function ToString(value MedicationKnowledgeStatus): value.value
+define function ToString(value MedicationRequestIntent): value.value
+define function ToString(value MedicationRequestPriority): value.value
+define function ToString(value MedicationRequestStatus): value.value
+define function ToString(value MedicationStatementStatus): value.value
+define function ToString(value MedicationStatus): value.value
+define function ToString(value MessageSignificanceCategory): value.value
+define function ToString(value Messageheader_Response_Request): value.value
+define function ToString(value MimeType): value.value
+define function ToString(value NameUse): value.value
+define function ToString(value NamingSystemIdentifierType): value.value
+define function ToString(value NamingSystemType): value.value
+define function ToString(value NarrativeStatus): value.value
+define function ToString(value NoteType): value.value
+define function ToString(value NutritiionOrderIntent): value.value
+define function ToString(value NutritionOrderStatus): value.value
+define function ToString(value ObservationDataType): value.value
+define function ToString(value ObservationRangeCategory): value.value
+define function ToString(value ObservationStatus): value.value
+define function ToString(value OperationKind): value.value
+define function ToString(value OperationParameterUse): value.value
+define function ToString(value OrientationType): value.value
+define function ToString(value ParameterUse): value.value
+define function ToString(value ParticipantRequired): value.value
+define function ToString(value ParticipantStatus): value.value
+define function ToString(value ParticipationStatus): value.value
+define function ToString(value PaymentNoticeStatus): value.value
+define function ToString(value PaymentReconciliationStatus): value.value
+define function ToString(value ProcedureStatus): value.value
+define function ToString(value PropertyRepresentation): value.value
+define function ToString(value PropertyType): value.value
+define function ToString(value ProvenanceEntityRole): value.value
+define function ToString(value PublicationStatus): value.value
+define function ToString(value QualityType): value.value
+define function ToString(value QuantityComparator): value.value
+define function ToString(value QuestionnaireItemOperator): value.value
+define function ToString(value QuestionnaireItemType): value.value
+define function ToString(value QuestionnaireResponseStatus): value.value
+define function ToString(value ReferenceHandlingPolicy): value.value
+define function ToString(value ReferenceVersionRules): value.value
+define function ToString(value ReferredDocumentStatus): value.value
+define function ToString(value RelatedArtifactType): value.value
+define function ToString(value RemittanceOutcome): value.value
+define function ToString(value RepositoryType): value.value
+define function ToString(value RequestIntent): value.value
+define function ToString(value RequestPriority): value.value
+define function ToString(value RequestStatus): value.value
+define function ToString(value ResearchElementType): value.value
+define function ToString(value ResearchStudyStatus): value.value
+define function ToString(value ResearchSubjectStatus): value.value
+define function ToString(value ResourceType): value.value
+define function ToString(value ResourceVersionPolicy): value.value
+define function ToString(value ResponseType): value.value
+define function ToString(value RestfulCapabilityMode): value.value
+define function ToString(value RiskAssessmentStatus): value.value
+define function ToString(value SPDXLicense): value.value
+define function ToString(value SearchComparator): value.value
+define function ToString(value SearchEntryMode): value.value
+define function ToString(value SearchModifierCode): value.value
+define function ToString(value SearchParamType): value.value
+define function ToString(value SectionMode): value.value
+define function ToString(value SequenceType): value.value
+define function ToString(value ServiceRequestIntent): value.value
+define function ToString(value ServiceRequestPriority): value.value
+define function ToString(value ServiceRequestStatus): value.value
+define function ToString(value SlicingRules): value.value
+define function ToString(value SlotStatus): value.value
+define function ToString(value SortDirection): value.value
+define function ToString(value SpecimenContainedPreference): value.value
+define function ToString(value SpecimenStatus): value.value
+define function ToString(value Status): value.value
+define function ToString(value StrandType): value.value
+define function ToString(value StructureDefinitionKind): value.value
+define function ToString(value StructureMapContextType): value.value
+define function ToString(value StructureMapGroupTypeMode): value.value
+define function ToString(value StructureMapInputMode): value.value
+define function ToString(value StructureMapModelMode): value.value
+define function ToString(value StructureMapSourceListMode): value.value
+define function ToString(value StructureMapTargetListMode): value.value
+define function ToString(value StructureMapTransform): value.value
+define function ToString(value SubscriptionChannelType): value.value
+define function ToString(value SubscriptionStatus): value.value
+define function ToString(value SupplyDeliveryStatus): value.value
+define function ToString(value SupplyRequestStatus): value.value
+define function ToString(value SystemRestfulInteraction): value.value
+define function ToString(value TaskIntent): value.value
+define function ToString(value TaskPriority): value.value
+define function ToString(value TaskStatus): value.value
+define function ToString(value TestReportActionResult): value.value
+define function ToString(value TestReportParticipantType): value.value
+define function ToString(value TestReportResult): value.value
+define function ToString(value TestReportStatus): value.value
+define function ToString(value TestScriptRequestMethodCode): value.value
+define function ToString(value TriggerType): value.value
+define function ToString(value TypeDerivationRule): value.value
+define function ToString(value TypeRestfulInteraction): value.value
+define function ToString(value UDIEntryType): value.value
+define function ToString(value UnitsOfTime): value.value
+define function ToString(value Use): value.value
+define function ToString(value VariableType): value.value
+define function ToString(value VisionBase): value.value
+define function ToString(value VisionEyes): value.value
+define function ToString(value VisionStatus): value.value
+define function ToString(value XPathUsageType): value.value
+define function ToString(value base64Binary): value.value
+define function ToBoolean(value boolean): value.value
+define function ToDate(value date): value.value
+define function ToDateTime(value dateTime): value.value
+define function ToDecimal(value decimal): value.value
+define function ToDateTime(value instant): value.value
+define function ToInteger(value integer): value.value
+define function ToString(value string): value.value
+define function ToTime(value time): value.value
+define function ToString(value uri): value.value
+define function ToString(value xhtml): value.value

--- a/input/resources/library/library-COVID_19_Concepts.json
+++ b/input/resources/library/library-COVID_19_Concepts.json
@@ -32,7 +32,7 @@
     }
   ],
   "name": "COVID_19_Concepts",
-  "title": "COVID-19 Shared Concepts and Terminology",
+  "title": "CQL Library - COVID-19 Shared Concepts and Terminology",
   "description": "COVID-19 Shared Concepts and Terminology imported by other CQL logic libraries.",
   "status": "active",
   "experimental": true,

--- a/input/resources/library/library-COVID_19_ED_Severity.json
+++ b/input/resources/library/library-COVID_19_ED_Severity.json
@@ -32,7 +32,7 @@
     }
   ],
   "name": "COVID_19_ED_Severity",
-  "title": "ACEP COVID-19 ED Severity Classification and Disposition Logic",
+  "title": "CQL Library - ACEP COVID-19 ED Severity Classification and Disposition Logic",
   "description": "This library contains logic to support the ACEP COVID-19 ED Severity Classification and Disposition guideline, including caclculation of the qCDI score and severity.",
   "status": "active",
   "experimental": true,

--- a/input/resources/library/library-COVID_19_ED_Severity_Hooks.json
+++ b/input/resources/library/library-COVID_19_ED_Severity_Hooks.json
@@ -17,7 +17,7 @@
     }
   ],
   "name": "COVID_19_ED_Severity_Hooks",
-  "title": "CDS Hooks for ACEP COVID-19 ED Severity Classification and Disposition Logic",
+  "title": "CQL Library - CDS Hooks for ACEP COVID-19 ED Severity Classification and Disposition Logic",
   "description": "This library contains logic to support CDS Hooks for the ACEP COVID-19 ED Severity Classification and Disposition guideline, including caclculation of the qCDI score and severity.",
   "status": "active",
   "experimental": true,

--- a/input/resources/library/library-FHIRHelpers.json
+++ b/input/resources/library/library-FHIRHelpers.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Library",
-  "id": "CDS-Connect-Commons",
+  "id": "FHIRHelpers-4.0.1",
   "meta": {
     "profile": [
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-shareablelibrary",
@@ -31,11 +31,11 @@
       "valueCode": "structured"
     }
   ],
-  "name": "CDS_Connect_Commons",
-  "title": "CQL Library - Common Logic for CDS",
-  "description": "CQL Common Logic for CDS providing shared helper functions.",
+  "name": "FHIRHelpers",
+  "title": "CQL Library - FHIR Helpers for CDS",
+  "description": "CQL Library - FHIR Helpers for CDS",
   "status": "active",
-  "experimental": true,
+  "experimental": false,
   "type": {
     "coding": [ {
       "system": "http://terminology.hl7.org/CodeSystem/library-type",
@@ -43,6 +43,6 @@
     } ]
   },
   "content": [ {
-    "id": "ig-loader-CDS_Connect_Commons_for_FHIRv400.cql"
+    "id": "ig-loader-FHIRHelpers.cql"
   } ]
 }

--- a/input/resources/plandefinition/PlanDefinition-COVID_19_ED_Severity.json
+++ b/input/resources/plandefinition/PlanDefinition-COVID_19_ED_Severity.json
@@ -29,7 +29,7 @@
   ],
   "version": "0.1.0",
   "name": "COVID_19_ED_Severity",
-  "title": "ACEP COVID-19 ED Severity Classification and Disposition",
+  "title": "PlanDefinition - ACEP COVID-19 ED Severity Classification and Disposition",
   "description": "CDS Hook definitions for ACEP COVID-19 ED Severity Classification and Disposition",
   "type": {
     "coding": [

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/1a876f28-f29e-58c3-9c52-0fdc345af3e1/patient_1a876f28-f29e-58c3-9c52-0fdc345af3e1.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/1a876f28-f29e-58c3-9c52-0fdc345af3e1/patient_1a876f28-f29e-58c3-9c52-0fdc345af3e1.json
@@ -39,7 +39,7 @@
         "resourceType": "Observation",
         "id": "85560e17-3520-5ece-8c6d-a4cd932240ea",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -64,7 +64,7 @@
         "resourceType": "Observation",
         "id": "59b4f1b3-f7e4-52c9-9692-0a71fbd2d80f",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -92,7 +92,7 @@
         "resourceType": "Observation",
         "id": "f4227323-9e34-52b0-bccd-8fca6bd64beb",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -120,7 +120,7 @@
         "resourceType": "Observation",
         "id": "98ff1fb4-7291-5fc1-aef1-edbfe6311273",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -131,6 +131,33 @@
         },
         "valueQuantity": {
           "value": 120.0,
+          "unit": "mmHg",
+          "system": "http://unitsofmeasure.org"
+        },
+        "subject": {
+          "reference": "Patient/1a876f28-f29e-58c3-9c52-0fdc345af3e1",
+          "identifier": {
+            "value": "1a876f28-f29e-58c3-9c52-0fdc345af3e1"
+          }
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "98ff1fb4-7291-5fc1-aef1-edbfe6311273-diastolic",
+        "status": "final",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8462-4"
+            }
+          ]
+        },
+        "valueQuantity": {
+          "value": 85.0,
           "unit": "mmHg",
           "system": "http://unitsofmeasure.org"
         },
@@ -147,7 +174,7 @@
         "resourceType": "Observation",
         "id": "a53e3ee5-c337-57bd-bf9c-1adccce167fb",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -172,9 +199,36 @@
     {
       "resource": {
         "resourceType": "Observation",
+        "id": "a53e3ee5-c337-57bd-bf9c-1adccce167fb-diastolic",
+        "status": "final",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8462-4"
+            }
+          ]
+        },
+        "valueQuantity": {
+          "value": 81,
+          "unit": "mmHg",
+          "system": "http://unitsofmeasure.org"
+        },
+        "subject": {
+          "reference": "Patient/1a876f28-f29e-58c3-9c52-0fdc345af3e1",
+          "identifier": {
+            "value": "1a876f28-f29e-58c3-9c52-0fdc345af3e1"
+          }
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
         "id": "022e0426-f751-5017-a24a-32cb8417a350",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -201,7 +255,7 @@
         "resourceType": "Observation",
         "id": "1ca2ce2d-3ae2-55fd-b05e-962f6765a9e5",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -226,7 +280,7 @@
         "resourceType": "Observation",
         "id": "0858838d-7924-5af3-9cd1-394c0b754893",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -251,7 +305,7 @@
         "resourceType": "Observation",
         "id": "95c37404-688f-51c0-affc-73ea4ca0605c",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -276,7 +330,7 @@
         "resourceType": "Observation",
         "id": "a0a44f34-5299-5ed2-8691-9c835dcf1953",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -303,7 +357,7 @@
         "resourceType": "Observation",
         "id": "7c7d9f25-51e1-5cc4-8e69-d0441420f40f",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -330,7 +384,7 @@
         "resourceType": "Observation",
         "id": "34cfcbf5-3b2b-59e1-9ede-78c54051e506",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -357,7 +411,7 @@
         "resourceType": "Observation",
         "id": "244bb1c5-e3e0-5222-91e3-4cf4b140c379",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -385,7 +439,7 @@
         "resourceType": "Observation",
         "id": "f4cd00c7-ed39-583e-bdce-ecb0a6d6668a",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -412,7 +466,7 @@
       "resource": {
         "resourceType": "Condition",
         "id": "ea85008d-78c5-5400-8404-34f3daf8f2d6",
-        "onsetDateTime": "2020-06-01T07:00:00-06:00",
+        "onsetDateTime": "2021-01-31T07:00:00-06:00",
         "clinicalStatus": {
           "coding": [
             {
@@ -471,7 +525,7 @@
         "resourceType": "Observation",
         "id": "5790efd8-a0d1-573e-b494-a6bf5ea78c8c",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -496,7 +550,7 @@
         "resourceType": "Observation",
         "id": "6ff44b83-c457-5101-8ad7-9d62a12a9851",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -521,7 +575,7 @@
         "resourceType": "Observation",
         "id": "791244e6-8c19-52ae-9b45-c7e0237bbe1f",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -546,7 +600,7 @@
         "resourceType": "Observation",
         "id": "32765946-3b16-51fa-9837-5446bb83d8bf",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -571,7 +625,7 @@
         "resourceType": "Observation",
         "id": "adb7f430-50c1-5283-abe3-60b7278e22b4",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -596,7 +650,7 @@
         "resourceType": "Observation",
         "id": "7a0fa511-1b99-5682-8631-a033ffdbe9ca",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -621,7 +675,7 @@
         "resourceType": "Observation",
         "id": "c48a4e93-6f04-58c0-b5ae-b67ab9a414af",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -646,7 +700,7 @@
         "resourceType": "Observation",
         "id": "77bdb5c6-5cb9-51a4-a8ee-4a1d362027af",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -671,7 +725,7 @@
         "resourceType": "Observation",
         "id": "3bbdc35e-107b-57fe-b75f-d3579476a795",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -696,7 +750,7 @@
         "resourceType": "Observation",
         "id": "2f4ea06c-ef8d-5d1d-89c1-79fc71ea3883",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -721,7 +775,7 @@
         "resourceType": "Observation",
         "id": "77e59968-efc3-5114-a0ed-40ac40b56a46",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -746,7 +800,7 @@
         "resourceType": "Observation",
         "id": "af2d9959-be68-5cf9-acf1-e7a6d91b322d",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -771,7 +825,7 @@
         "resourceType": "DiagnosticReport",
         "id": "dce51834-3241-5912-aa01-1bc07996dc80",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -794,7 +848,7 @@
         "resourceType": "DiagnosticReport",
         "id": "18def6f5-5535-52b2-8bf9-8023c01acd77",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/94296005-b7b2-5a13-a2c0-641d8ac2f1bd/patient_94296005-b7b2-5a13-a2c0-641d8ac2f1bd.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/94296005-b7b2-5a13-a2c0-641d8ac2f1bd/patient_94296005-b7b2-5a13-a2c0-641d8ac2f1bd.json
@@ -39,7 +39,7 @@
         "resourceType": "Observation",
         "id": "3a1d613a-223d-53d7-8d12-22525f219892",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -67,7 +67,7 @@
         "resourceType": "Observation",
         "id": "8b35cb04-2640-54f3-9b26-2f9a08560709",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -95,7 +95,7 @@
         "resourceType": "Observation",
         "id": "3ad99d9a-02f2-5b27-81bb-2efb518a846e",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -123,7 +123,7 @@
         "resourceType": "Observation",
         "id": "5461cc10-5546-5ec5-a83e-01b960eb426f",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -150,7 +150,7 @@
         "resourceType": "Observation",
         "id": "6af9b0a1-d66f-5be8-9fdf-12b474f3eef8",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -177,7 +177,7 @@
         "resourceType": "Observation",
         "id": "7e2993eb-e908-520f-b6a3-96593ff62140",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -204,7 +204,7 @@
         "resourceType": "Observation",
         "id": "6ea6cbe8-4183-5a43-b270-9bdd06a8956e",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -229,7 +229,7 @@
         "resourceType": "Observation",
         "id": "504bc414-c5f0-5e8e-956c-0897d25ca77c",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -254,7 +254,7 @@
         "resourceType": "Observation",
         "id": "fa297428-ae45-5743-bcc6-04912e6f6979",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -279,7 +279,7 @@
         "resourceType": "Observation",
         "id": "3be9e348-6d7d-5017-a8b1-542f6294cfc0",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -306,7 +306,7 @@
         "resourceType": "Observation",
         "id": "775a46ed-c202-596f-a4c2-b0fe618413e5",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -333,7 +333,7 @@
         "resourceType": "Observation",
         "id": "df577154-5b4a-594e-b336-346d6219cc7e",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -360,7 +360,7 @@
         "resourceType": "Observation",
         "id": "ae44c365-b45b-50fc-9011-3e4b09d266c9",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T07:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T07:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -388,7 +388,7 @@
         "resourceType": "Observation",
         "id": "a9d3d5e4-c305-5017-95a9-2c0fa716c578",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T08:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T08:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -416,7 +416,7 @@
         "resourceType": "Observation",
         "id": "be39d642-ee44-5b68-a239-7637f4624711",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -443,7 +443,7 @@
       "resource": {
         "resourceType": "Condition",
         "id": "25b162f1-8e01-5184-8d5f-90f27a9ca4dd",
-        "onsetDateTime": "2020-06-01T07:00:00-06:00",
+        "onsetDateTime": "2021-01-31T07:00:00-06:00",
         "clinicalStatus": {
           "coding": [
             {
@@ -496,7 +496,7 @@
       "resource": {
         "resourceType": "Condition",
         "id": "18d7b228-789f-5177-b456-49caecd283f3",
-        "onsetDateTime": "2020-06-01T07:00:00-06:00",
+        "onsetDateTime": "2021-01-31T07:00:00-06:00",
         "clinicalStatus": {
           "coding": [
             {
@@ -550,7 +550,7 @@
         "resourceType": "Observation",
         "id": "b9b11c64-67a2-5f19-af69-a506118b92a2",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -575,7 +575,7 @@
         "resourceType": "Observation",
         "id": "e5a1c1b8-397f-533f-b19b-75dfb930ec6e",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -600,7 +600,7 @@
         "resourceType": "Observation",
         "id": "eca34fd5-ae8a-576a-91b3-92f13bb7f738",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -625,7 +625,7 @@
         "resourceType": "Observation",
         "id": "c90c7280-e626-5992-9892-01b4a63820bc",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -650,7 +650,7 @@
         "resourceType": "Observation",
         "id": "d3c7dccc-3017-558e-bb4e-35a6fcb792a4",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -675,7 +675,7 @@
         "resourceType": "Observation",
         "id": "f3af92a1-5315-50da-991e-6af02e16ed82",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -700,7 +700,7 @@
         "resourceType": "Observation",
         "id": "22ae2583-8551-507a-a597-5e9977955752",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -725,7 +725,7 @@
         "resourceType": "Observation",
         "id": "b0cbce5a-6cf1-5c69-b8dd-10c887a3502e",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -750,7 +750,7 @@
         "resourceType": "Observation",
         "id": "5bd11ed9-6bab-5262-8358-d855f7f1cc74",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -775,7 +775,7 @@
         "resourceType": "Observation",
         "id": "ddfe45cf-5d92-57ff-962b-ab4d491caa69",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -800,7 +800,7 @@
         "resourceType": "Observation",
         "id": "c537acf5-f9eb-54ad-b4ec-99e7eec55e22",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -825,7 +825,7 @@
         "resourceType": "Observation",
         "id": "f66416a5-d97d-5952-8e94-859ed4dde2a8",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T10:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T10:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -850,7 +850,7 @@
         "resourceType": "DiagnosticReport",
         "id": "bab962a0-5231-5865-8bd8-73a9867c0d02",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {
@@ -873,7 +873,7 @@
         "resourceType": "DiagnosticReport",
         "id": "c6eb9642-836a-59e2-b86f-5a16f4b38c2a",
         "status": "final",
-        "effectiveDateTime": "2020-06-01T09:00:00-06:00",
+        "effectiveDateTime": "2021-01-31T09:00:00-06:00",
         "code": {
           "coding": [
             {

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-1-demographic.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-1-demographic.json
@@ -79,7 +79,7 @@
           }
         ],
         "gender": "male",
-        "birthDate": "1949-10-07",
+        "birthDate": "1952-10-07",
         "telecom": [
           {
             "system": "phone",

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-1-demographic.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-1-demographic.json
@@ -1,0 +1,109 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Patient/va-pat-dan"
+      },
+      "resource": {
+        "resourceType": "Patient",
+        "id": "va-pat-dan",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Dan Smith</div>"
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+            "extension": [
+              {
+                "url" : "ombCategory",
+                "valueCoding" : {
+                  "system" : "urn:oid:2.16.840.1.113883.6.238",
+                  "code" : "2106-3",
+                  "display" : "White"
+                }
+              },
+              {
+                "url" : "text",
+                "valueString" : "White"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+            "extension" : [
+              {
+                "url" : "ombCategory",
+                "valueCoding" : {
+                  "system" : "urn:oid:2.16.840.1.113883.6.238",
+                  "code" : "2186-5",
+                  "display" : "Not Hispanic or Latino"
+                }
+              },
+              {
+                "url" : "text",
+                "valueString" : "Not Hispanic or Latino"
+              }
+            ]
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueCode": "M"
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://va.gov/fhir/NamingSystem/identifier",
+            "value": "VA-101"
+          },
+          {
+            "system": "http://www.demohospital.org/identifiers/test",
+            "value": "demo"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "McDaniels",
+            "given": [
+              "Dan"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1949-10-07",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "555-555-2002",
+            "use": "mobile"
+          },
+          {
+            "system": "email",
+            "value": "dan@woohoo.com"
+          }
+        ],
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "3009 17th Street"
+            ],
+            "city": "Salem",
+            "postalCode": "24153",
+            "state": "VA",
+            "country": "USA"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-2-conditions.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-2-conditions.json
@@ -1,0 +1,426 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/va-cond-dan-concern-foot"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "va-cond-dan-concern-foot",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div>Peripheral vascular and neuropathy risks leading to heightened foot complication risks</div></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
+                "code": "health-concern"
+              }
+            ],
+            "text": "Health Concern"
+          }
+        ],
+        "code": {
+          "text": "Peripheral vascular and neuropathy risks leading to heightened foot complication risks"
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan",
+          "display": "Dan"
+        },
+        "onsetDateTime": "2020-06-19"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/va-cond-dan-concern-glucose"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "va-cond-dan-concern-glucose",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div>Inability to maintain effective blood glucose control</div></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
+                "code": "health-concern"
+              }
+            ],
+            "text": "Health Concern"
+          }
+        ],
+        "code": {
+          "text": "Inability to maintain effective blood glucose control"
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan",
+          "display": "Dan"
+        },
+        "onsetDateTime": "2020-07-17"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/va-cond-dan-depression"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "va-cond-dan-depression",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div>Depression</div></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ],
+            "text": "Problem"
+          }
+        ],
+        "severity": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "6736007",
+              "display": "Moderate"
+            }
+          ],
+          "text": "Moderate"
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "35489007",
+              "display": "Depression"
+            }
+          ],
+          "text": "Depression"
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan",
+          "display": "Dan"
+        },
+        "onsetDateTime": "2018-06-15"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/va-cond-dan-dm"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "va-cond-dan-dm",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div>Type 2 diabetes mellitus</div></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ],
+            "text": "Problem"
+          }
+        ],
+        "severity": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "6736007",
+              "display": "Moderate"
+            }
+          ],
+          "text": "Moderate"
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "44054006",
+              "display": "Type 2 diabetes mellitus"
+            }
+          ],
+          "text": "Type 2 diabetes mellitus"
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan",
+          "display": "Dan"
+        },
+        "onsetDateTime": "2011-06-17"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/va-cond-dan-hypertension"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "va-cond-dan-hypertension",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div>Hypertension</div></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ],
+            "text": "Problem"
+          }
+        ],
+        "severity": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "6736007",
+              "display": "Moderate"
+            }
+          ],
+          "text": "Moderate"
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "59621000",
+              "display": "Essential hypertension (disorder)"
+            }
+          ],
+          "text": "Essential hypertension (disorder)"
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan",
+          "display": "Dan"
+        },
+        "onsetDateTime": "2017-04-30"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Condition/va-cond-dan-ptsd"
+      },
+      "resource": {
+        "resourceType": "Condition",
+        "id": "va-cond-dan-ptsd",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div>PTSD</div></div>"
+        },
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "active",
+              "display": "Active"
+            }
+          ],
+          "text": "Active"
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "confirmed",
+              "display": "Confirmed"
+            }
+          ],
+          "text": "Confirmed"
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item",
+                "display": "Problem List Item"
+              }
+            ],
+            "text": "Problem"
+          }
+        ],
+        "severity": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "371923003",
+              "display": "Mild to moderate"
+            }
+          ],
+          "text": "Mild to moderate"
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "47505003",
+              "display": "Posttraumatic stress disorder"
+            }
+          ],
+          "text": "PTSD - Posttraumatic stress disorder"
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan",
+          "display": "Dan"
+        },
+        "onsetDateTime": "1988-02-17"
+      }
+    }
+  ]
+}

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals-bp.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals-bp.json
@@ -1,0 +1,671 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-bp-1"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-bp-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2018-05-15",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 138,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 77,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-bp-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-bp-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2018-09-22",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 135,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 77,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-bp-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-bp-3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2019-04-15",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 142,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 79,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-bp-4"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-bp-4",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2019-09-11",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 141,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 76,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-bp-5"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-bp-5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2020-03-25",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 135,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 79,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-bp"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-bp",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2020-08-15",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 143,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 82,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-bp-6"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-bp-6",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2020-09-03",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 147,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 83,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals-covid.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals-covid.json
@@ -39,9 +39,9 @@
         "subject": {
           "reference": "Patient/va-pat-dan"
         },
-        "effectiveDateTime": "2021-01-29T07:00:00-06:00",
+        "effectiveDateTime": "2021-02-03T07:00:00-06:00",
         "valueQuantity": {
-          "value": 86,
+          "value": 89,
           "unit": "%",
           "system": "http://unitsofmeasure.org",
           "code": "%"
@@ -85,9 +85,9 @@
         "subject": {
           "reference": "Patient/va-pat-dan"
         },
-        "effectiveDateTime": "2021-01-29T08:00:00-06:00",
+        "effectiveDateTime": "2021-02-03T08:00:00-06:00",
         "valueQuantity": {
-          "value": 94,
+          "value": 91,
           "unit": "%",
           "system": "http://unitsofmeasure.org",
           "code": "%"
@@ -131,13 +131,717 @@
         "subject": {
           "reference": "Patient/va-pat-dan"
         },
-        "effectiveDateTime": "2021-01-29T08:00:00-06:00",
+        "effectiveDateTime": "2021-02-03T09:00:00-06:00",
         "valueQuantity": {
-          "value": 96,
+          "value": 94,
           "unit": "%",
           "system": "http://unitsofmeasure.org",
           "code": "%"
         }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-temperature"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-temperature",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Body temperature</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8310-5",
+              "display": "Body temperature"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T07:05:00-06:00",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "valueQuantity": {
+          "value": 102.1,
+          "unit": "degF",
+          "system": "http://unitsofmeasure.org",
+          "code": "[degF]"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-heartrate-1"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-heartrate-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8867-4",
+              "display": "Heart rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T07:00:00-06:00",
+        "valueQuantity": {
+          "value": 105.0,
+          "unit": "beats/minute",
+          "system": "http://unitsofmeasure.org"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-heartrate-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-heartrate-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8867-4",
+              "display": "Heart rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T08:00:00-06:00",
+        "valueQuantity": {
+          "value": 110.0,
+          "unit": "beats/minute",
+          "system": "http://unitsofmeasure.org"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-heartrate-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-heartrate-3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8867-4",
+              "display": "Heart rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T09:00:00-06:00",
+        "valueQuantity": {
+          "value": 97.0,
+          "unit": "beats/minute",
+          "system": "http://unitsofmeasure.org"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-respiratory-1"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-respiratory-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "9279-1",
+              "display": "Respiratory rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T07:00:00-06:00",
+        "valueQuantity": {
+          "value": 30.0,
+          "unit": "breaths/minute",
+          "system": "http://unitsofmeasure.org",
+          "code": "/min"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-respiratory-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-respiratory-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "9279-1",
+              "display": "Respiratory rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T08:00:00-06:00",
+        "valueQuantity": {
+          "value": 26.0,
+          "unit": "breaths/minute",
+          "system": "http://unitsofmeasure.org",
+          "code": "/min"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-respiratory-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-respiratory-3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "9279-1",
+              "display": "Respiratory rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T09:00:00-06:00",
+        "valueQuantity": {
+          "value": 22.0,
+          "unit": "breaths/minute",
+          "system": "http://unitsofmeasure.org",
+          "code": "/min"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-o2flow-1"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-o2flow-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "3151-8",
+              "display": "Inhaled oxygen flow rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T07:00:00-06:00",
+        "valueQuantity": {
+          "value": 3.0,
+          "unit": "L/min",
+          "system": "http://unitsofmeasure.org"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-o2flow-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-o2flow-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "3151-8",
+              "display": "Inhaled oxygen flow rate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T08:00:00-06:00",
+        "valueQuantity": {
+          "value": 4.0,
+          "unit": "L/min",
+          "system": "http://unitsofmeasure.org"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-c19-bp-1"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-c19-bp-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T07:00:00-06:00",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 120,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 77,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-c19-bp-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-c19-bp-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T08:00:00-06:00",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 84,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 70,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/cc-obs-dan-c19-bp-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "cc-obs-dan-c19-bp-3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/Observation"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Blood pressure</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "85354-9",
+              "display": "Blood pressure systolic and diastolic"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-02-03T09:00:00-06:00",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "bodySite": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "368209003",
+              "display": "Right arm"
+            }
+          ]
+        },
+        "component": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8480-6",
+                  "display": "Systolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 92,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "8462-4",
+                  "display": "Diastolic blood pressure"
+                }
+              ]
+            },
+            "valueQuantity": {
+              "value": 81,
+              "unit": "mmHg",
+              "system": "http://unitsofmeasure.org",
+              "code": "mm[Hg]"
+            }
+          }
+        ]
       }
     }
   ]

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals-covid.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals-covid.json
@@ -1,0 +1,144 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-o2sat-1"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-o2sat-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2708-6",
+              "display": "Oxygen saturation in Arterial blood"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-01-29T07:00:00-06:00",
+        "valueQuantity": {
+          "value": 86,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-o2sat-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-o2sat-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2708-6",
+              "display": "Oxygen saturation in Arterial blood"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-01-29T08:00:00-06:00",
+        "valueQuantity": {
+          "value": 94,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-o2sat-3"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-o2sat-3",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2708-6",
+              "display": "Oxygen saturation in Arterial blood"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2021-01-29T08:00:00-06:00",
+        "valueQuantity": {
+          "value": 96,
+          "unit": "%",
+          "system": "http://unitsofmeasure.org",
+          "code": "%"
+        }
+      }
+    }
+  ]
+}

--- a/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals.json
+++ b/input/tests/COVID_19_ED_Severity_FHIRv400/va-pat-dan/va-dan-5-vitals.json
@@ -1,0 +1,230 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-weight"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-weight",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Body weight</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "29463-7",
+              "display": "Body weight"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2018-03-30",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "valueQuantity": {
+          "value": 188,
+          "unit": "lb",
+          "system": "http://unitsofmeasure.org",
+          "code": "[lb_av]"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-weight-1"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-weight-1",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Body weight</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "29463-7",
+              "display": "Body weight"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2018-10-15",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "valueQuantity": {
+          "value": 179,
+          "unit": "lb",
+          "system": "http://unitsofmeasure.org",
+          "code": "[lb_av]"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-weight-2"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-weight-2",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Body weight</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "29463-7",
+              "display": "Body weight"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2020-08-03",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "valueQuantity": {
+          "value": 182,
+          "unit": "lb",
+          "system": "http://unitsofmeasure.org",
+          "code": "[lb_av]"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/va-obs-dan-height"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "id": "va-obs-dan-height",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Body height</div>"
+        },
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "vital-signs"
+              }
+            ],
+            "text": "Vital Signs"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "8302-2",
+              "display": "Body height"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/va-pat-dan"
+        },
+        "effectiveDateTime": "2020-08-03",
+        "performer": [
+          {
+            "reference": "Practitioner/va-prac-visn6-francis",
+            "display": "Dr. Francis, MD"
+          }
+        ],
+        "valueQuantity": {
+          "value": 71,
+          "unit": "in",
+          "system": "http://unitsofmeasure.org",
+          "code": "[in_i]"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
CQL supports blood pressure as either separate Observations for systolic and diastolic, or combined as components within one Observation (as required for US Core).