### PR TITLE
743 january acep updates

### DIFF
--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -11,11 +11,9 @@ import { buildAllNullRiskAssessmentScoreParameters } from '../helpers/builders';
 describe('treatment summary', () => {
     it.each([
         ['Recommend Non-Pharmacologic Treatment'],
-        ['Recommend Antibodies Treatment'],
-        ['Recommend Anticoagulation Treatment'],
-        ['Recommend Steroids Treatment'],
-        ['Recommend Remdesivir Treatment'],
-        ['Recommend SteroidsAndOrRemdesivir Treatment'],
+        ['Recommend Mild Severity Treatment'],
+        ['Recommend Moderate Severity Treatment'],
+        ['Recommend Severe and Critical Severity Treatment'],
         ])( '%p returns null when all inputs are null', (expressionName: string ) => {
         const cqlExpressionParameters = buildCQLExpressionParameters({}, buildAllNullRiskAssessmentScoreParameters());
         const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, expressionName);
@@ -53,14 +51,14 @@ describe('treatment summary', () => {
 
     it.each([
             ['mild', 'use', new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', 'use', new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
+            ['moderate', null, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
             ['severe', null, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
             ['critical', null, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
             ['none', null, {}],
         ]
     )('For %p severity, Recommend Antibodies Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Antibodies Treatment');
+        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Mild Severity Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
 

--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -12,7 +12,7 @@ describe('treatment summary', () => {
     it.each([
         ['Recommend Non-Pharmacologic Treatment'],
         ['Recommend Admission Treatment'],
-        ['Recommend Discharged Treatment'],
+        ['Recommend Discharge Treatment'],
         ['Recommend Steroids Treatment']
         ])( '%p returns null when all inputs are null', (expressionName: string ) => {
         const cqlExpressionParameters = buildCQLExpressionParameters({}, buildAllNullRiskAssessmentScoreParameters());
@@ -58,7 +58,7 @@ describe('treatment summary', () => {
         ]
     )('For %p severity, Recommend DischargeHome Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Discharged Treatment');
+        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Discharge Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
 

--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -11,9 +11,9 @@ import { buildAllNullRiskAssessmentScoreParameters } from '../helpers/builders';
 describe('treatment summary', () => {
     it.each([
         ['Recommend Non-Pharmacologic Treatment'],
-        ['Recommend Mild Severity Treatment'],
-        ['Recommend Moderate Severity Treatment'],
-        ['Recommend Severe and Critical Severity Treatment'],
+        ['Recommend Admission Treatment'],
+        ['Recommend Discharged Treatment'],
+        ['Recommend Steroids Treatment']
         ])( '%p returns null when all inputs are null', (expressionName: string ) => {
         const cqlExpressionParameters = buildCQLExpressionParameters({}, buildAllNullRiskAssessmentScoreParameters());
         const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, expressionName);
@@ -51,14 +51,14 @@ describe('treatment summary', () => {
 
     it.each([
             ['mild', 'use', new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', null, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
+            ['moderate', 'use', new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
             ['severe', null, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
             ['critical', null, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
             ['none', null, {}],
         ]
-    )('For %p severity, Recommend Antibodies Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
+    )('For %p severity, Recommend DischargeHome Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Mild Severity Treatment');
+        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Discharged Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
 
@@ -69,9 +69,9 @@ describe('treatment summary', () => {
             ['critical', 'use', new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
             ['none', null, {}],
         ]
-    )('For %p severity, Recommend Anticoagulation Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
+    )('For %p severity, Recommend Addmission Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Anticoagulation Treatment');
+        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Admission Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
 
@@ -85,32 +85,6 @@ describe('treatment summary', () => {
     )('For %p severity, Recommend Steroids Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
         const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Steroids Treatment');
-        expect(recommendNonPharma).toEqual(expectedRecommendation);
-    });
-
-    it.each([
-            ['mild', 'insufficient-evidence', new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', 'insufficient-evidence', new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
-            ['severe', null, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-            ['critical', null, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-            ['none', null, {}],
-        ]
-    )('For %p severity, Recommend Remdesivir Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
-        const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Remdesivir Treatment');
-        expect(recommendNonPharma).toEqual(expectedRecommendation);
-    });
-
-    it.each([
-            ['mild', null, new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', null, new ClinicalAssessmentBuilder().withModerateSeverity().build()],
-            ['severe', 'use', new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-            ['critical', 'use', new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-            ['none', null, {}],
-        ]
-    )('For %p severity, Recommend SteroidsAndOrRemdesivir Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
-        const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend SteroidsAndOrRemdesivir Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
 });

--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -37,10 +37,10 @@ describe('treatment summary', () => {
     });
 
     it.each([
-          ['mild', 'use', new ClinicalAssessmentBuilder().withMildSeverity().build()],
-          ['moderate', 'use', new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
-          ['severe', 'use', new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-          ['critical', 'use', new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+          ['mild', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+          ['moderate', true, new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
+          ['severe', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
+          ['critical', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
           ['none', null, {}],
         ]
     )('For %p severity, Recommend Non-Pharmacologic Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
@@ -50,8 +50,8 @@ describe('treatment summary', () => {
     });
 
     it.each([
-            ['mild', 'use', new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', 'use', new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
+            ['mild', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+            ['moderate', true, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
             ['severe', null, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
             ['critical', null, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
             ['none', null, {}],
@@ -64,9 +64,9 @@ describe('treatment summary', () => {
 
     it.each([
             ['mild', null, new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', 'use', new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
-            ['severe', 'use', new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-            ['critical', 'use', new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+            ['moderate', true, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
+            ['severe', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
+            ['critical', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
             ['none', null, {}],
         ]
     )('For %p severity, Recommend Addmission Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
@@ -76,8 +76,8 @@ describe('treatment summary', () => {
     });
 
     it.each([
-            ['mild', 'do-not-use', new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', 'do-not-use', new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
+            ['mild', false, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+            ['moderate', false, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
             ['severe', null, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
             ['critical', null, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
             ['none', null, {}],

--- a/input/cql/COVID19EmergencyDeptSummary.cql
+++ b/input/cql/COVID19EmergencyDeptSummary.cql
@@ -71,10 +71,10 @@ define DispositionSummary: {
   CriticalAdmission: "Recommend Critical Admission"
 }
 
-// Value: use, do-not-use, insufficient-evidence, null
+// Value: true and false, null
 define TreatmentSummary: {
     NonPharmacologic: "Recommend Non-Pharmacologic Treatment",
-    Discharge: "Recommend Discharged Treatment",
+    Discharge: "Recommend Discharge Treatment",
     Admission: "Recommend Admission Treatment",
     Steroids: "Recommend Steroids Treatment"
 }
@@ -299,7 +299,7 @@ define "Recommend Non-Pharmacologic Treatment":
 
 // Pharmacologic Treatment
 // Recommend discharge from emergency department treamtment for mild and moderate severity.
-define "Recommend Discharged Treatment":
+define "Recommend Discharge Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
   else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then true
   else null

--- a/input/cql/COVID19EmergencyDeptSummary.cql
+++ b/input/cql/COVID19EmergencyDeptSummary.cql
@@ -74,11 +74,9 @@ define DispositionSummary: {
 // Value: use, do-not-use, insufficient-evidence, null
 define TreatmentSummary: {
   NonPharmacologic: "Recommend Non-Pharmacologic Treatment",
-  Antibodies: "Recommend Antibodies Treatment",
-  Anticoagulation: "Recommend Anticoagulation Treatment",
-  Remdesivir: "Recommend Remdesivir Treatment",
-  Steroids: "Recommend Steroids Treatment",
-  SteroidsAndOrRemdesivir: "Recommend SteroidsAndOrRemdesivir Treatment"
+  MildPharmacologicTreatment: "Recommend Mild Severity Treatment",
+  ModeratePharmacologicTreatment: "Recommend Moderate Severity Treatment",
+  SevereCriticalPharmacologicTreatment: "Recommend Severe and Critical Severity Treatment"
 }
 
 define AssessmentSummary: {
@@ -299,27 +297,18 @@ define "Recommend Non-Pharmacologic Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
   else 'use'
 
-define "Recommend Antibodies Treatment":
+// Pharmacologic Treatment
+define "Recommend Mild Severity Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'use'
+  else if (C19."Is Mild Severity") then 'use'
   else null
 
-define "Recommend Anticoagulation Treatment":
+define "Recommend Moderate Severity Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Moderate Severity" or C19."Is Severe Severity" or C19."Is Critical Severity") then 'use'
+  else if (C19."Is Moderate Severity") then 'use'
   else null
 
-define "Recommend Steroids Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'do-not-use'
-  else null
-
-define "Recommend Remdesivir Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then null
-  else if C19."Is Mild Severity" or C19."Is Moderate Severity" then 'insufficient-evidence'
-  else null
-
-define "Recommend SteroidsAndOrRemdesivir Treatment":
+define "Recommend Severe and Critical Severity Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
   else if (C19."Is Severe Severity" or C19."Is Critical Severity") then 'use'
   else null

--- a/input/cql/COVID19EmergencyDeptSummary.cql
+++ b/input/cql/COVID19EmergencyDeptSummary.cql
@@ -73,10 +73,10 @@ define DispositionSummary: {
 
 // Value: use, do-not-use, insufficient-evidence, null
 define TreatmentSummary: {
-  NonPharmacologic: "Recommend Non-Pharmacologic Treatment",
-  DischargedTreatment: "Recommend Discharged Treatment",
-  AdmissionTreatment: "Recommend Admission Treatment",
-  SteroidsTreatment: "Recommend Steroids Treatment"
+    NonPharmacologic: "Recommend Non-Pharmacologic Treatment",
+    Discharge: "Recommend Discharged Treatment",
+    Admission: "Recommend Admission Treatment",
+    Steroids: "Recommend Steroids Treatment"
 }
 
 define AssessmentSummary: {
@@ -295,25 +295,25 @@ define HasAdmissionOrDischargeRecommendation:
 
 define "Recommend Non-Pharmacologic Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else 'use'
+  else true
 
 // Pharmacologic Treatment
-// Recommand discharge from emergency department treamtment for mild and moderate severity.
+// Recommend discharge from emergency department treamtment for mild and moderate severity.
 define "Recommend Discharged Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'use'
+  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then true
   else null
 
-// Recommand admission to emergency department treamtment for moderate, severe and critical severity.
+// Recommend admission to emergency department treamtment for moderate, severe and critical severity.
 define "Recommend Admission Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Moderate Severity" or C19."Is Severe Severity" or C19."Is Critical Severity") then 'use'
+  else if (C19."Is Moderate Severity" or C19."Is Severe Severity" or C19."Is Critical Severity") then true
   else null
 
 //Do not use steriods for mild and moderate severity
 define "Recommend Steroids Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'do-not-use'
+  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then false
   else null
 
 /*

--- a/input/cql/COVID19EmergencyDeptSummary.cql
+++ b/input/cql/COVID19EmergencyDeptSummary.cql
@@ -74,9 +74,9 @@ define DispositionSummary: {
 // Value: use, do-not-use, insufficient-evidence, null
 define TreatmentSummary: {
   NonPharmacologic: "Recommend Non-Pharmacologic Treatment",
-  MildPharmacologicTreatment: "Recommend Mild Severity Treatment",
-  ModeratePharmacologicTreatment: "Recommend Moderate Severity Treatment",
-  SevereCriticalPharmacologicTreatment: "Recommend Severe and Critical Severity Treatment"
+  DischargedTreatment: "Recommend Discharged Treatment",
+  AdmissionTreatment: "Recommend Admission Treatment",
+  SteroidsTreatment: "Recommend Steroids Treatment"
 }
 
 define AssessmentSummary: {
@@ -298,19 +298,22 @@ define "Recommend Non-Pharmacologic Treatment":
   else 'use'
 
 // Pharmacologic Treatment
-define "Recommend Mild Severity Treatment":
+// Recommand discharge from emergency department treamtment for mild and moderate severity.
+define "Recommend Discharged Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Mild Severity") then 'use'
+  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'use'
   else null
 
-define "Recommend Moderate Severity Treatment":
+// Recommand admission to emergency department treamtment for moderate, severe and critical severity.
+define "Recommend Admission Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Moderate Severity") then 'use'
+  else if (C19."Is Moderate Severity" or C19."Is Severe Severity" or C19."Is Critical Severity") then 'use'
   else null
 
-define "Recommend Severe and Critical Severity Treatment":
+//Do not use steriods for mild and moderate severity
+define "Recommend Steroids Treatment":
   if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Severe Severity" or C19."Is Critical Severity") then 'use'
+  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'do-not-use'
   else null
 
 /*


### PR DESCRIPTION
Categorized treatment into Admission, Discharge instead of individual treatment type. Steriods are still separate since it is part of the 'Do not use'  treatment that is displayed differently on the UI.

The named expression returns a boolean or null instead of strings (`use` `do-not-use`), which makes the logic no the UI simplier. 

Ticket: [743](https://app.zenhub.com/workspaces/covid-patient-manager-5fc9453d958e1600153602d5/issues/department-of-veterans-affairs/covid-patient-manager/743) 

