### PR TITLE
[#763] Add Non-Pharmacologic treatment functions based on severity

### DIFF
--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -10,9 +10,7 @@ import { buildAllNullRiskAssessmentScoreParameters } from '../helpers/builders';
 
 describe('treatment summary', () => {
     it.each([
-        ['Recommend MildAndModerate Non-Pharmacologic Treatment'],
-        ['Recommend Severe Non-Pharmacologic Treatment'],
-        ['Recommend Critical Non-Pharmacologic Treatment'],
+        ['Recommend Non-Pharmacologic Treatment'],
         ['Recommend Admission Treatment'],
         ['Recommend Discharge Treatment'],
         ['Recommend Steroids Treatment']
@@ -27,10 +25,10 @@ describe('treatment summary', () => {
         ['Moderate', 'Admission', 2, new ClinicalAssessmentBuilder().withModerateSeverity().build() ],
         ['Severe', 'Admission', 1, new ClinicalAssessmentBuilder().withSevereSeverity().build() ],
         ['Severe',  'Discharge', 2 , new ClinicalAssessmentBuilder().withSevereSeverity().build() ]
-        ])( 'For %p severity display order for %p is %p ', (expressionName: string, treatmentType: string, priorityOrder: number, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters> ) => {
+        ])( 'For %p severity display order for %p is %p ', (expressionName: string, treatmentId: string, priorityOrder: number, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters> ) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides, buildAllNullRiskAssessmentScoreParameters());
         const treatmentSummaryList = executeSummaryCQLExpression(cqlExpressionParameters, 'TreatmentSummary');
-        const treatment = treatmentSummaryList.filter((t) => t.TreatmentType === treatmentType);
+        const treatment = treatmentSummaryList.filter((t) => t.TreatmentId === treatmentId);
         expect(treatment[0].PriorityOrder).toBe(priorityOrder);
     
     })
@@ -53,13 +51,13 @@ describe('treatment summary', () => {
     });
 
     it.each([
-          ['mild', 'Recommend MildAndModerate Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
-          ['moderate','Recommend MildAndModerate Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
-          ['severe', 'Recommend Severe Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-          ['critical', 'Recommend Critical Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-          ['none', 'Recommend MildAndModerate Non-Pharmacologic Treatment', false, {}],
-          ['none', 'Recommend Severe Non-Pharmacologic Treatment', false, {}],
-          ['none', 'Recommend Critical Non-Pharmacologic Treatment', false, {}],
+          ['mild', 'Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+          ['moderate','Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
+          ['severe', 'Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
+          ['critical', 'Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+          ['none', 'Recommend Non-Pharmacologic Treatment', false, {}],
+          ['none', 'Recommend Non-Pharmacologic Treatment', false, {}],
+          ['none', 'Recommend Non-Pharmacologic Treatment', false, {}],
         ]
     )('For %p severity, %p is %p', (severityType: string, treatment: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);

--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -10,14 +10,16 @@ import { buildAllNullRiskAssessmentScoreParameters } from '../helpers/builders';
 
 describe('treatment summary', () => {
     it.each([
-        ['Recommend Non-Pharmacologic Treatment'],
+        ['Recommend MildAndModerate Non-Pharmacologic Treatment'],
+        ['Recommend Severe Non-Pharmacologic Treatment'],
+        ['Recommend Critical Non-Pharmacologic Treatment'],
         ['Recommend Admission Treatment'],
         ['Recommend Discharge Treatment'],
         ['Recommend Steroids Treatment']
-        ])( '%p returns null when all inputs are null', (expressionName: string ) => {
+        ])( '%p returns false when all inputs are null', (expressionName: string ) => {
         const cqlExpressionParameters = buildCQLExpressionParameters({}, buildAllNullRiskAssessmentScoreParameters());
         const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, expressionName);
-        expect(recommendNonPharma).toEqual(null);
+        expect(recommendNonPharma).toEqual(false);
     });
 
     it.each([
@@ -51,15 +53,17 @@ describe('treatment summary', () => {
     });
 
     it.each([
-          ['mild', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
-          ['moderate', true, new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
-          ['severe', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-          ['critical', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-          ['none', null, {}],
+          ['mild', 'Recommend MildAndModerate Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+          ['moderate','Recommend MildAndModerate Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
+          ['severe', 'Recommend Severe Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
+          ['critical', 'Recommend Critical Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+          ['none', 'Recommend MildAndModerate Non-Pharmacologic Treatment', false, {}],
+          ['none', 'Recommend Severe Non-Pharmacologic Treatment', false, {}],
+          ['none', 'Recommend Critical Non-Pharmacologic Treatment', false, {}],
         ]
-    )('For %p severity, Recommend Non-Pharmacologic Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
+    )('For %p severity, %p is %p', (severityType: string, treatment: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Non-Pharmacologic Treatment');
+        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, treatment);
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
 
@@ -67,8 +71,8 @@ describe('treatment summary', () => {
             ['mild', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
             ['moderate', true, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
             ['severe', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-            ['critical', null, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-            ['none', null, {}],
+            ['critical', false, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+            ['none', false, {}],
         ]
     )('For %p severity, Recommend DischargeHome Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
@@ -77,11 +81,11 @@ describe('treatment summary', () => {
     });
 
     it.each([
-            ['mild', null, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+            ['mild', false, new ClinicalAssessmentBuilder().withMildSeverity().build()],
             ['moderate', true, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
             ['severe', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
             ['critical', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-            ['none', null, {}],
+            ['none', false, {}],
         ]
     )('For %p severity, Recommend Addmission Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
@@ -90,11 +94,11 @@ describe('treatment summary', () => {
     });
 
     it.each([
-            ['mild', false, new ClinicalAssessmentBuilder().withMildSeverity().build()],
-            ['moderate', false, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
-            ['severe', null, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-            ['critical', null, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-            ['none', null, {}],
+            ['mild', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+            ['moderate', true, new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
+            ['severe', false, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
+            ['critical', false, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+            ['none', false, {}],
         ]
     )('For %p severity, Recommend Steroids Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);

--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -101,4 +101,18 @@ describe('treatment summary', () => {
         const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Steroids Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
+
+    it.each([
+        ['mild', 'NonPharmaMildModerate', new ClinicalAssessmentBuilder().withMildSeverity().build()],
+        ['moderate', 'NonPharmaMildModerate', new ClinicalAssessmentBuilder().withModerateSeverity().withConcerningLab(1).build()],
+        ['severe', 'NonPharmaSevere', new ClinicalAssessmentBuilder().withSevereSeverity().build()],
+        ['critical', 'NonPharmaCritical', new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+        ['none', "invalid", {}],
+    ]
+    )('For %p severity, Non-Pharmacologic Treatment Id is %p', (severityType: string, treatmentId: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
+        const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
+        const treatment_id = executeSummaryCQLExpression(cqlExpressionParameters, 'Non-Pharmacologic Treatment Id');
+        expect(treatment_id).toEqual(treatmentId);
+    });
+    
 });

--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -57,7 +57,7 @@ describe('treatment summary', () => {
           ['critical', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
           ['none', false, {}]
         ]
-    )('For %p severity, %p is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
+    )('For %p severity, Recommend Non-Pharmacologic Treatment is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
         const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Non-Pharmacologic Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);

--- a/cql-unit-tests/test/treatmentSummary.test.ts
+++ b/cql-unit-tests/test/treatmentSummary.test.ts
@@ -51,17 +51,15 @@ describe('treatment summary', () => {
     });
 
     it.each([
-          ['mild', 'Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
-          ['moderate','Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
-          ['severe', 'Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
-          ['critical', 'Recommend Non-Pharmacologic Treatment', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
-          ['none', 'Recommend Non-Pharmacologic Treatment', false, {}],
-          ['none', 'Recommend Non-Pharmacologic Treatment', false, {}],
-          ['none', 'Recommend Non-Pharmacologic Treatment', false, {}],
+          ['mild', true, new ClinicalAssessmentBuilder().withMildSeverity().build()],
+          ['moderate', true, new ClinicalAssessmentBuilder().withConcerningLab(1).withMildSeverity().build()],
+          ['severe', true, new ClinicalAssessmentBuilder().withSevereSeverity().build()],
+          ['critical', true, new ClinicalAssessmentBuilder().withCriticalSeverity().build()],
+          ['none', false, {}]
         ]
-    )('For %p severity, %p is %p', (severityType: string, treatment: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
+    )('For %p severity, %p is %p', (severityType: string, expectedRecommendation: string, clinicalAssessmentOverrides: Partial<ClinicalAssessmentsParameters>) => {
         const cqlExpressionParameters = buildCQLExpressionParameters(clinicalAssessmentOverrides);
-        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, treatment);
+        const recommendNonPharma = executeSummaryCQLExpression(cqlExpressionParameters, 'Recommend Non-Pharmacologic Treatment');
         expect(recommendNonPharma).toEqual(expectedRecommendation);
     });
 

--- a/input/cql/COVID19EmergencyDeptSummary.cql
+++ b/input/cql/COVID19EmergencyDeptSummary.cql
@@ -76,33 +76,23 @@ define TreatmentSummary:
   if ( C19."Is Severe Severity" ) then  
     {
       {
-        TreatmentType: 'NonPharmaMildModerate',
+        TreatmentId: "Non-Pharmacologic Treatment Id",
         PriorityOrder: 0,
-        Recommend: "Recommend MildAndModerate Non-Pharmacologic Treatment"
+        Recommend: "Recommend Non-Pharmacologic Treatment"
       },
       {
-        TreatmentType: 'NonPharmaSevere',
-        PriorityOrder: 0,
-        Recommend: "Recommend Severe Non-Pharmacologic Treatment"
-      },
-      {
-        TreatmentType: 'NonPharmaCritical',
-        PriorityOrder: 0,
-        Recommend: "Recommend Critical Non-Pharmacologic Treatment"
-      },
-      {
-        TreatmentType: 'Admission',
+        TreatmentId: 'Admission',
         PriorityOrder: 1,
         Recommend: "Recommend Admission Treatment"
       
       },
       {
-        TreatmentType: 'Discharge',
+        TreatmentId: 'Discharge',
         PriorityOrder: 2,
         Recommend: "Recommend Discharge Treatment"
       },
       {
-        TreatmentType: 'Steroids',
+        TreatmentId: 'Steroids',
         PriorityOrder: 3,
         Recommend: "Recommend Steroids Treatment"
       }
@@ -110,32 +100,22 @@ define TreatmentSummary:
   else
   {
     {
-      TreatmentType: 'NonPharmaMildModerate',
-      PriorityOrder: 0,
-      Recommend: "Recommend MildAndModerate Non-Pharmacologic Treatment"
+        TreatmentId: "Non-Pharmacologic Treatment Id",
+        PriorityOrder: 0,
+        Recommend: "Recommend Non-Pharmacologic Treatment"
     },
     {
-      TreatmentType: 'NonPharmaSevere',
-      PriorityOrder: 0,
-      Recommend: "Recommend Severe Non-Pharmacologic Treatment"
-    },
-    {
-      TreatmentType: 'NonPharmaCritical',
-      PriorityOrder: 0,
-      Recommend: "Recommend Critical Non-Pharmacologic Treatment"
-    },
-    {
-      TreatmentType: 'Discharge',
+      TreatmentId: 'Discharge',
       PriorityOrder: 1,
       Recommend: "Recommend Discharge Treatment"
     },
     {
-      TreatmentType: 'Admission',
+      TreatmentId: 'Admission',
       PriorityOrder: 2,
       Recommend: "Recommend Admission Treatment"
     },
     {
-      TreatmentType: 'Steroids',
+      TreatmentId: 'Steroids',
       PriorityOrder: 3,
       Recommend: "Recommend Steroids Treatment"
     }
@@ -359,20 +339,17 @@ define HasAdmissionOrDischargeRecommendation:
   DispositionSummary.ConsiderAdmission or DispositionSummary.SevereAdmission or DispositionSummary.CriticalAdmission
   or DispositionSummary.DischargeHome or DispositionSummary.ConsiderDischargingHome or DispositionSummary.DischargeHomeElevatedRisk
 
-define "Recommend MildAndModerate Non-Pharmacologic Treatment":
+
+define "Recommend Non-Pharmacologic Treatment":
   if HasAdmissionOrDischargeRecommendation is false then false
-  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then true
+  else if (C19."Is Mild Severity" or C19."Is Moderate Severity" or C19."Is Severe Severity" or C19."Is Critical Severity") then true
   else false
 
-define "Recommend Severe Non-Pharmacologic Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then false
-  else if (C19."Is Severe Severity") then true
-  else false
-
-define "Recommend Critical Non-Pharmacologic Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then false
-  else if (C19."Is Critical Severity") then true
-  else false
+define "Non-Pharmacologic Treatment Id":
+ if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'NonPharmaMildModerate'
+ else if (C19."Is Severe Severity")  then 'NonPharmaMildSevere'
+ else if (C19."Is Critical Severity") then 'NonPharmaCritical'
+ else 'invalid'
 
 // Pharmacologic Treatment
 // Recommend discharge from emergency department treamtment for mild and moderate severity.

--- a/input/cql/COVID19EmergencyDeptSummary.cql
+++ b/input/cql/COVID19EmergencyDeptSummary.cql
@@ -76,14 +76,25 @@ define TreatmentSummary:
   if ( C19."Is Severe Severity" ) then  
     {
       {
-        TreatmentType: 'NonPharmacologic',
+        TreatmentType: 'NonPharmaMildModerate',
         PriorityOrder: 0,
-        Recommend: "Recommend Non-Pharmacologic Treatment"
+        Recommend: "Recommend MildAndModerate Non-Pharmacologic Treatment"
+      },
+      {
+        TreatmentType: 'NonPharmaSevere',
+        PriorityOrder: 0,
+        Recommend: "Recommend Severe Non-Pharmacologic Treatment"
+      },
+      {
+        TreatmentType: 'NonPharmaCritical',
+        PriorityOrder: 0,
+        Recommend: "Recommend Critical Non-Pharmacologic Treatment"
       },
       {
         TreatmentType: 'Admission',
         PriorityOrder: 1,
         Recommend: "Recommend Admission Treatment"
+      
       },
       {
         TreatmentType: 'Discharge',
@@ -99,9 +110,19 @@ define TreatmentSummary:
   else
   {
     {
-      TreatmentType: 'NonPharmacologic',
+      TreatmentType: 'NonPharmaMildModerate',
       PriorityOrder: 0,
-      Recommend: "Recommend Non-Pharmacologic Treatment"
+      Recommend: "Recommend MildAndModerate Non-Pharmacologic Treatment"
+    },
+    {
+      TreatmentType: 'NonPharmaSevere',
+      PriorityOrder: 0,
+      Recommend: "Recommend Severe Non-Pharmacologic Treatment"
+    },
+    {
+      TreatmentType: 'NonPharmaCritical',
+      PriorityOrder: 0,
+      Recommend: "Recommend Critical Non-Pharmacologic Treatment"
     },
     {
       TreatmentType: 'Discharge',
@@ -338,28 +359,39 @@ define HasAdmissionOrDischargeRecommendation:
   DispositionSummary.ConsiderAdmission or DispositionSummary.SevereAdmission or DispositionSummary.CriticalAdmission
   or DispositionSummary.DischargeHome or DispositionSummary.ConsiderDischargingHome or DispositionSummary.DischargeHomeElevatedRisk
 
-define "Recommend Non-Pharmacologic Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then null
-  else true
+define "Recommend MildAndModerate Non-Pharmacologic Treatment":
+  if HasAdmissionOrDischargeRecommendation is false then false
+  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then true
+  else false
+
+define "Recommend Severe Non-Pharmacologic Treatment":
+  if HasAdmissionOrDischargeRecommendation is false then false
+  else if (C19."Is Severe Severity") then true
+  else false
+
+define "Recommend Critical Non-Pharmacologic Treatment":
+  if HasAdmissionOrDischargeRecommendation is false then false
+  else if (C19."Is Critical Severity") then true
+  else false
 
 // Pharmacologic Treatment
 // Recommend discharge from emergency department treamtment for mild and moderate severity.
 define "Recommend Discharge Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then null
+  if HasAdmissionOrDischargeRecommendation is false then false
   else if (C19."Is Mild Severity" or C19."Is Moderate Severity" or C19."Is Severe Severity" ) then true
-  else null
+  else false
 
 // Recommend admission to emergency department treamtment for moderate, severe and critical severity.
 define "Recommend Admission Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then null
+  if HasAdmissionOrDischargeRecommendation is false then false
   else if (C19."Is Moderate Severity" or C19."Is Severe Severity" or C19."Is Critical Severity") then true
-  else null
+  else false
 
 //Do not use steriods for mild and moderate severity
 define "Recommend Steroids Treatment":
-  if HasAdmissionOrDischargeRecommendation is false then null
-  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then false
-  else null
+  if HasAdmissionOrDischargeRecommendation is false then false
+  else if (C19."Is Mild Severity" or C19."Is Moderate Severity") then true
+  else false
 
 /*
  * Helper functions for summary reporting.

--- a/input/cql/COVID19EmergencyDeptSummary.cql
+++ b/input/cql/COVID19EmergencyDeptSummary.cql
@@ -347,7 +347,7 @@ define "Recommend Non-Pharmacologic Treatment":
 
 define "Non-Pharmacologic Treatment Id":
  if (C19."Is Mild Severity" or C19."Is Moderate Severity") then 'NonPharmaMildModerate'
- else if (C19."Is Severe Severity")  then 'NonPharmaMildSevere'
+ else if (C19."Is Severe Severity")  then 'NonPharmaSevere'
  else if (C19."Is Critical Severity") then 'NonPharmaCritical'
  else 'invalid'
 


### PR DESCRIPTION
Moved the business logic to determine the different non-pharmacologic based on the severity which previously resided on the CPM PatientTreatment.tsx file.